### PR TITLE
feat(Dependency): Turn waitFor into an array

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Subrequests format",
   "description": "Describes the subrequests payload format.",
   "type": "array",
@@ -34,8 +35,7 @@
         "uri": {
           "title": "URI",
           "description": "The URI where to make the subrequest.",
-          "type": "string",
-          "format": "uri"
+          "type": "string"
         },
         "requestId": {
           "title": "Request ID",
@@ -60,8 +60,12 @@
         },
         "waitFor": {
           "title": "Parent ID",
-          "description": "ID of another request that is a dependeny for this one.",
-          "type": "string"
+          "description": "ID of other requests that this request depends on.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "ID of another request that is a dependency for this one."
+          }
         }
       }
     }

--- a/schema.json
+++ b/schema.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Subrequests format",
   "description": "Describes the subrequests payload format.",
   "type": "array",


### PR DESCRIPTION
This will bring the implementation up to speed with the latest version of the spec.

BREAKING CHANGE: waitFor is now an array of dependencies instead of a single string